### PR TITLE
Fix: Set accessToken cookie for static asset auth fallback (图片上传变黑修复)

### DIFF
--- a/packages/locales/src/zh/index.js
+++ b/packages/locales/src/zh/index.js
@@ -1,6 +1,10 @@
 // Translated by FANJT2024
+// Updated by solider245 — added action, activity, core imports
 import merge from 'lodash/merge';
 
+import action from './action';
+import activity from './activity';
+import core from './core';
 import error from './error';
 import login from './login';
 
@@ -8,6 +12,6 @@ export default {
   language: 'zh',
   country: 'cn',
   name: '中文',
-  embeddedLocale: merge(error, login),
+  embeddedLocale: merge(action, activity, core, error, login),
   flags: ['CN'],
 };

--- a/server/api/controllers/access-tokens/create.js
+++ b/server/api/controllers/access-tokens/create.js
@@ -59,6 +59,13 @@ module.exports = {
       userAgent: this.req.headers['user-agent'],
     });
 
+    this.res.cookie('accessToken', accessToken, {
+      maxAge: 365 * 24 * 60 * 60 * 1000,
+      httpOnly: false,
+      sameSite: 'lax',
+      path: '/',
+    });
+
     return {
       item: accessToken,
     };

--- a/server/api/controllers/register/create.js
+++ b/server/api/controllers/register/create.js
@@ -97,6 +97,13 @@ module.exports = {
 
     const accessToken = sails.helpers.utils.createToken(user.id);
     await Session.create({ accessToken, remoteAddress: this.req.connection.remoteAddress, userId: user.id, userAgent: this.req.headers['user-agent'] });
+    this.res.cookie('accessToken', accessToken, {
+      maxAge: 365 * 24 * 60 * 60 * 1000,
+      httpOnly: false,
+      sameSite: 'lax',
+      path: '/',
+    });
+
     return {
       item: accessToken,
     };

--- a/server/api/hooks/current-user/index.js
+++ b/server/api/hooks/current-user/index.js
@@ -34,6 +34,18 @@ module.exports = function defineCurrentUserHook(sails) {
                   currentUser,
                 });
 
+                // Set cookie so <img> tags on the same origin can authenticate
+                // Fixes issue where uploaded attachment images render as black
+                // https://github.com/RARgames/4gaBoards/issues/27
+                if (!req.cookies || req.cookies.accessToken !== accessToken) {
+                  res.cookie('accessToken', accessToken, {
+                    maxAge: 365 * 24 * 60 * 60 * 1000,
+                    httpOnly: false,
+                    sameSite: 'lax',
+                    path: '/',
+                  });
+                }
+
                 if (req.isSocket) {
                   sails.sockets.join(req, `@user:${currentUser.id}`);
                 }


### PR DESCRIPTION
## 问题 / Problem

上传的卡片封面图片渲染为全黑。Issue #27 曾报告过此问题 ("White image in attachment gets totally black")，但当时作者标记为 "Cannot reproduce" 后关闭。

Root cause: 浏览器 <img> 标签发起的 GET 请求不带 Authorization: Bearer <token> header。而 4gaBoards 前端仅通过 localStorage 存储 token，通过 fetch/XHR 的 Authorization header 发送。后端 /attachments/* 路由挂载了 is-authenticated 策略，没有 Authorization header 就会返回 401，图片加载失败，暗色主题下呈现为黑色方块。

The browser <img> tag issues plain GET requests to /attachments/* which carry no Authorization header. The backend requires authentication on these endpoints via the is-authenticated policy. Since the frontend stores the token in localStorage only (sent via Authorization header on XHR calls), all <img> requests get 401, rendering as black on dark theme.

---

## 修复 / Fix

后端已有 cookie 鉴权能力: hooks/current-user/index.js 中的 /attachments/* 和 /exports/* 路由已经会检查 req.cookies.accessToken。问题是没有地方实际设置这个 cookie。

三个文件各加一行 res.cookie() 调用:

**1. access-tokens/create.js** - 登录成功后种 cookie
**2. register/create.js** - 注册成功后种 cookie
**3. hooks/current-user/index.js** - /api/* 路由验证 Authorization header 通过后补种 cookie (覆盖 token 续期/会话重用场景)

The backend already had cookie-based auth handling in the current-user hook for /attachments/* and /exports/* routes (they check req.cookies.accessToken), but the cookie was never set by any controller. This PR adds res.cookie() calls to all three entry points.

Cookie attributes:
- httpOnly: false (frontend can read it alongside localStorage)
- sameSite: lax (preserved across same-origin navigations)
- path: / (available site-wide)
- maxAge: 1 year (matches token expiry convention)

---

## 验证 / Verification

在正式部署环境验证通过:
- 登录响应包含 Set-Cookie: accessToken=...
- <img src="/attachments/.../cover-256.png"> 请求携带 Cookie -> 200 OK
- 不带 Cookie -> 仍返回 401 (安全策略无退化)
- 上传的图片正常显示

Verified on production deployment:
- Login response includes Set-Cookie: accessToken=...
- <img> requests with Cookie -> 200 OK
- Without Cookie -> still returns 401 (no security regression)
- Uploaded images render correctly

---

Fixes #27
