### PR TITLE
test: add E2E tests for board and card workflow

### DIFF
--- a/ai-interaction.md
+++ b/ai-interaction.md
@@ -1,0 +1,64 @@
+# AI Interaction Log — 4ga Boards E2E Take-Home
+
+## How I Used AI
+
+In this exercise, I acted as the decision maker — defining scope, making design calls, and reviewing all output. AI tooling acted as the executor — exploring the codebase, generating code, and assisting with debugging. I reviewed everything before it was finalized.
+
+I started by prompting the AI assistant to "explore the project and identify main features for E2E testing", then directed the implementation from there.
+
+Specifically, I used AI tooling for:
+- **Codebase exploration**: reading component files, locale strings, and router paths to help identify stable selectors and relevant components more efficiently
+- **Code generation**: page objects, spec files, fixture
+- **Debugging**: AI-assisted debugging using Playwright traces, screenshots, and failure logs, which I reviewed and confirmed
+
+---
+
+## My Decisions
+
+### 1. What to test
+
+I identified two P0 feature areas that cover the core user workflow:
+- **Authentication** — without login, nothing else works
+- **Kanban workflow** — creating boards, lists, and cards is the core value of the product
+
+I also decided to extend the existing test structure rather than rewrite it, since login and user management tests were already on the branch.
+
+### 2. Test scope
+
+I directed the AI to cover both happy path and negative cases. Negative cases were important to include because they verify the app handles invalid input correctly — not just that the golden path works.
+
+### 3. Tagging strategy
+
+The AI initially designed `@smoke` and `@regression` as two independent suites. I questioned this — a regression suite should include smoke tests, not be separate from them. Running regression but skipping smoke doesn't make sense. This led us to simplify: only tag `@smoke` for the critical happy path, and run everything for full coverage.
+
+### 4. Eliminating login boilerplate
+
+I noticed every spec was repeating the same login steps. I asked the AI to extract this into a shared fixture so login is handled automatically before each test.
+
+### 5. Keeping the test plan focused
+
+The AI included POM explanations, fixture details, and design decisions inside `test-plan.md`. I pushed back — a test plan should focus on what is being tested, not how it is implemented. The file was trimmed to test cases and running instructions only.
+
+---
+
+## What AI Contributed
+
+- Read through source components to identify stable selectors
+- Generated page objects (`BoardPage.ts`, `CardPage.ts`) and spec files (`board.spec.ts`, `card.spec.ts`)
+- Implemented `auth.fixture.ts` based on my direction
+- Assisted with failure analysis using screenshots and logs
+
+---
+
+## Division of Work
+
+AI assisted with:
+- Codebase exploration
+- Initial code generation
+- Failure analysis
+
+I was responsible for:
+- Feature selection and prioritization
+- Test scope and coverage decisions
+- Reviewing selectors and implementation quality
+- Final validation and cleanup

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.28.6",
+    "@playwright/test": "^1.60.0",
     "concurrently": "^9.2.1",
     "confusing-browser-globals": "^1.0.11",
     "eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,10 @@ importers:
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.28.6
-        version: 7.28.6(@babel/core@7.29.0)(eslint@9.39.4)
+        version: 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0))
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -30,28 +33,28 @@ importers:
         version: 1.0.11
       eslint:
         specifier: ^9.39.4
-        version: 9.39.4
+        version: 9.39.4(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.4)
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import-x:
         specifier: ^4.16.2
-        version: 4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)
+        version: 4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
-        version: 6.10.2(eslint@9.39.4)
+        version: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-perfectionist:
         specifier: ^5.9.0
-        version: 5.9.0(eslint@9.39.4)(typescript@6.0.3)
+        version: 5.9.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
       eslint-plugin-react:
         specifier: ^7.37.5
-        version: 7.37.5(eslint@9.39.4)
+        version: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@9.39.4)
+        version: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       lint-staged:
         specifier: ^17.0.3
         version: 17.0.3
@@ -9527,18 +9530,18 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4)':
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -10400,7 +10403,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10800,17 +10803,12 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
-    dependencies:
-      eslint: 9.39.4
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -10826,7 +10824,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -12423,7 +12421,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -12445,7 +12443,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
@@ -12454,13 +12452,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.2(eslint@9.39.4)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -12746,7 +12744,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13720,10 +13718,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -14097,9 +14091,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.4):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -14108,13 +14102,13 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.11.1
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.59.2
       comment-parser: 1.4.6
-      debug: 4.4.3
-      eslint: 9.39.4
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.2.5
@@ -14122,11 +14116,11 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -14136,7 +14130,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -14145,36 +14139,37 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-perfectionist@5.9.0(eslint@9.39.4)(typescript@6.0.3):
+  eslint-plugin-perfectionist@5.9.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4)(typescript@6.0.3)
-      eslint: 9.39.4
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.7.0)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.39.4)
+      '@types/eslint': 9.6.1
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
 
-  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.3
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.4):
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -14182,7 +14177,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
@@ -14222,45 +14217,6 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       webpack: 5.106.2
-
-  eslint@9.39.4:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
-      '@eslint/js': 9.39.4
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@9.39.4(jiti@2.7.0):
     dependencies:
@@ -14602,7 +14558,7 @@ snapshots:
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
 
   for-each@0.3.5:
     dependencies:
@@ -15148,7 +15104,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18868,7 +18824,7 @@ snapshots:
       arg: 5.0.2
       bluebird: 3.7.2
       check-more-types: 2.24.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       execa: 5.1.1
       lazy-ass: 1.6.0
       tree-kill: 1.2.2
@@ -19074,7 +19030,7 @@ snapshots:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       css-functions-list: 3.3.3
       css-tree: 3.2.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
       file-entry-cache: 11.1.3

--- a/test-plan.md
+++ b/test-plan.md
@@ -1,0 +1,104 @@
+# E2E Test Plan — 4ga Boards
+
+## Features Under Test
+
+This plan focuses on two core feature areas, with additional coverage for admin user management:
+
+1. **Authentication** — prerequisite for accessing protected application workflows
+2. **Board and card workflow** — core Kanban functionality used for organizing and tracking work items
+3. **User management** — admin workflow for managing user accounts
+
+---
+
+## Test Cases
+
+### 1. Authentication (`login.spec.ts`)
+
+| ID | Description | Tag |
+|----|-------------|-----|
+| AUTH-01 | Admin logs in with valid credentials → redirected to dashboard | `@smoke` |
+| AUTH-02 | Login with wrong password → error message shown, stays on login page | — |
+
+---
+
+### 2. User Management (`addUser.spec.ts`)
+
+| ID | Description | Tag |
+|----|-------------|-----|
+| USER-01 | Admin creates a new user → user appears in users list | — |
+
+---
+
+### 3. Board Management (`board.spec.ts`)
+
+| ID | Description | Tag |
+|----|-------------|-----|
+| BOARD-01 | Admin creates a board → navigated to board page, board title visible | `@smoke` |
+| BOARD-02 | Admin adds a list to a board → list appears on board | `@smoke` |
+| BOARD-03 | Submit empty board name → validation error shown, board is not created | — |
+| BOARD-04 | Submit empty list name → validation error shown, list is not created | — |
+
+---
+
+### 4. Card Management (`card.spec.ts`)
+
+| ID | Description | Tag |
+|----|-------------|-----|
+| CARD-01 | Admin creates a card in a list → card appears in list | `@smoke` |
+| CARD-02 | Admin opens a card → URL changes to `/cards/:id`, modal visible | — |
+| CARD-03 | Admin closes the card modal → URL returns to `/boards/:id` | — |
+
+---
+
+## Test Suites
+
+| Suite | When to run | Command |
+|-------|------------|---------|
+| Smoke | PR validation / deploy verification | `playwright test --grep @smoke` |
+| Full | Nightly or pre-release regression | `playwright test` |
+
+---
+
+## Stability Considerations
+
+- Prefer user-facing attributes (`title`) over CSS class selectors, which get hashed by CSS Modules
+- Rely on Playwright auto-waiting and assertions rather than fixed waits
+- Use unique timestamp-based test data to reduce cross-test interference
+- Keep tests independent — each test creates and cleans up its own data in a `finally` block
+
+---
+
+## Running Tests
+
+All commands must be run from the `tests/` directory in the project root.
+
+```bash
+cd tests
+
+# Full suite
+pnpm test
+
+# Smoke tests only
+pnpm exec playwright test --grep @smoke
+
+# Single spec file
+pnpm exec playwright test e2e/specs/board.spec.ts
+
+# Single test by name
+pnpm exec playwright test --grep "invalid credentials"
+
+# Single test within a specific file
+pnpm exec playwright test e2e/specs/login.spec.ts --grep "invalid credentials"
+
+# With UI (headed)
+pnpm test:headed
+
+# Single test with UI
+pnpm exec playwright test e2e/specs/login.spec.ts --grep "invalid credentials" --headed
+
+# Single test with UI (slow motion, e.g. 1000ms between each step)
+PLAYWRIGHT_SLOW_MO=1000 pnpm exec playwright test e2e/specs/login.spec.ts --grep "invalid credentials" --headed
+
+# UI mode — step through each action, pause and replay
+pnpm exec playwright test e2e/specs/login.spec.ts --ui
+```

--- a/tests/e2e/pageObjects/BoardPage.ts
+++ b/tests/e2e/pageObjects/BoardPage.ts
@@ -1,0 +1,67 @@
+import { expect, Page } from '@playwright/test';
+
+export class BoardPage {
+  public readonly page: Page;
+  public readonly baseUrl: string;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.baseUrl = 'http://localhost:3000';
+  }
+
+  async createProject(name: string): Promise<string> {
+    await this.page.locator("button[title='Add Project']").first().click();
+    const input = this.page.locator("input[placeholder='Enter project name...']");
+    await input.waitFor({ state: 'visible' });
+    await input.fill(name);
+    await input.press('Enter');
+    await this.page.waitForURL(/\/projects\/\w+/, { timeout: 15000 });
+    const match = this.page.url().match(/\/projects\/(\w+)/);
+    return match ? match[1] : '';
+  }
+
+  async deleteProject(projectId: string): Promise<void> {
+    await this.page.goto(`${this.baseUrl}/projects/${projectId}/settings`);
+    await this.page.locator("button[title='Delete Project']").click();
+    await this.page.locator("button[title='Delete project']").click();
+    await this.page.waitForURL(this.baseUrl + '/');
+  }
+
+  async createBoard(name: string, projectName: string): Promise<string> {
+    await this.page.locator("button[title='Add Board']").first().click();
+    const nameInput = this.page.locator("input[placeholder='Enter board name...']");
+    await nameInput.waitFor({ state: 'visible' });
+    await nameInput.fill(name);
+
+    // Select project from dropdown only if not already pre-selected
+    const needsSelection = await this.page.locator("input[title='Select project']").isVisible({ timeout: 2000 }).catch(() => false);
+    if (needsSelection) {
+      await this.page.locator("input[title='Select project']").click();
+      await this.page.getByRole('dialog').getByText(projectName, { exact: true }).click();
+    }
+
+    // Submit via Enter on the name input (bubbles up to form's keyDown handler)
+    await nameInput.press('Enter');
+    await this.page.waitForURL(/\/boards\/\w+/, { timeout: 15000 });
+    const match = this.page.url().match(/\/boards\/(\w+)/);
+    return match ? match[1] : '';
+  }
+
+  async deleteBoard(): Promise<void> {
+    // Use nth(1) — nth(0) is the sidebar hover button, nth(1) is the board header button
+    await this.page.locator("button[title='Edit Board']").nth(1).click();
+    await this.page.locator("button[title='Delete Board']").first().click();
+    await this.page.locator("button[title='Delete Board']").click();
+    // Best-effort wait — board is async deleted, cleanup doesn't need to block long
+    await this.page.waitForURL(/\/(projects\/\w+|)$/, { timeout: 5000 }).catch(() => {});
+  }
+
+  async createList(name: string): Promise<void> {
+    // Board trigger: title='Add List' (common locale, capital L)
+    // Form submit:   title='Add list' (action locale, lowercase l)
+    await this.page.locator("button[title='Add List']").click();
+    await this.page.locator("textarea[placeholder='Enter list name...']").fill(name);
+    await this.page.locator("button[title='Add list']").click();
+    await expect(this.page.locator(`div[title='${name}']`)).toBeVisible({ timeout: 10000 });
+  }
+}

--- a/tests/e2e/pageObjects/CardPage.ts
+++ b/tests/e2e/pageObjects/CardPage.ts
@@ -1,0 +1,30 @@
+import { expect, Page } from '@playwright/test';
+
+export class CardPage {
+  public readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async createCard(cardName: string): Promise<void> {
+    // Trigger: title='Add Card' (capital C, from t('common.addCard'))
+    // The CardAdd inline form is always in DOM but hidden; clicking trigger shows it
+    await this.page.locator("button[title='Add Card']").first().click();
+    const textarea = this.page.locator("textarea[placeholder='Enter card name... [Ctrl+Enter] - open']");
+    await textarea.waitFor({ state: 'visible' });
+    await textarea.fill(cardName);
+    await textarea.press('Enter');
+    await expect(this.page.locator(`div[title='${cardName}']`)).toBeVisible({ timeout: 10000 });
+  }
+
+  async openCard(cardName: string): Promise<void> {
+    await this.page.locator(`div[title='${cardName}']`).click();
+    await expect(this.page.locator("button[title='Close Card']")).toBeVisible({ timeout: 10000 });
+  }
+
+  async closeCard(): Promise<void> {
+    await this.page.locator("button[title='Close Card']").click();
+    await expect(this.page.locator("button[title='Close Card']")).not.toBeVisible({ timeout: 5000 });
+  }
+}

--- a/tests/e2e/pageObjects/UserSettingPage.ts
+++ b/tests/e2e/pageObjects/UserSettingPage.ts
@@ -54,8 +54,8 @@ export class UserSettingPage {
 
     await row.scrollIntoViewIfNeeded();
     await row.locator("button[title='Edit User']").click();
-    await this.page.locator("button[title='Delete User']").click();
-    await this.page.locator("button[title='Delete User']").click();
+    await this.page.locator("button[title='Delete user']").click();
+    await this.page.locator("button[title='Delete user']").click();
 
     await expect(row).toHaveCount(0);
   }

--- a/tests/e2e/specs/addUser.spec.ts
+++ b/tests/e2e/specs/addUser.spec.ts
@@ -1,52 +1,44 @@
-import { test, expect } from '@playwright/test';
-import { LoginPage } from '../pageObjects/LoginPage';
+import { test, expect } from '../../fixtures/auth.fixture';
 import { UserSettingPage } from '../pageObjects/UserSettingPage';
 
-test('admin user can create a new user', async ({ page }) => {
-  const loginPage = new LoginPage(page);
-  const userSettingPage = new UserSettingPage(page);
-  const createdUserEmails: string[] = [];
+test.describe('User management', () => {
+  test('admin can create a new user', async ({ authenticatedPage: page }) => {
+    const userSettingPage = new UserSettingPage(page);
+    const createdUserEmails: string[] = [];
 
-  const user = {
-    email: 'test_user@gmail.com',
-    password: 'Abcde@123',
-    name: 'test user',
-    username: 'test_user',
-  };
+    const user = {
+      email: 'test_user@gmail.com',
+      password: 'Abcde@123',
+      name: 'test user',
+      username: 'test_user',
+    };
 
-  try {
-    await test.step('Log in as admin', async () => {
-      await loginPage.navigateToLoginPage();
-      await expect(page).toHaveURL(loginPage.loginUrl);
-      await loginPage.loginToDashboard('demo', 'demo');
-      await expect(page).toHaveURL(loginPage.dashboardUrl);
-      await expect(loginPage.dashboardTitle).toBeVisible({ timeout: 15000 });
-    });
-
-    await test.step('Navigate to users setting page', async () => {
-      await userSettingPage.navigateToUsersSettingPage();
-    });
-
-    await test.step('Create new user', async () => {
-      await userSettingPage.addUserButton.click();
-      await userSettingPage.addUser(user.email, user.password, user.name, user.username);
-      createdUserEmails.push(user.email);
-    });
-
-    await test.step('Verify new user appears in list', async () => {
-      await expect(page.locator(`div[title='${user.email}']`)).toBeVisible();
-    });
-  } finally {
-    if (!createdUserEmails.length) {
-      return;
-    }
-
-    await userSettingPage.navigateToUsersSettingPage();
-
-    for (const email of [...createdUserEmails].reverse()) {
-      await userSettingPage.deleteUserByEmail(email).catch((error: unknown) => {
-        console.warn(`Cleanup failed for user ${email}:`, error);
+    try {
+      await test.step('Navigate to users setting page', async () => {
+        await userSettingPage.navigateToUsersSettingPage();
       });
+
+      await test.step('Create new user', async () => {
+        await userSettingPage.addUserButton.click();
+        await userSettingPage.addUser(user.email, user.password, user.name, user.username);
+        createdUserEmails.push(user.email);
+      });
+
+      await test.step('Verify new user appears in list', async () => {
+        await expect(page.locator(`div[title='${user.email}']`)).toBeVisible();
+      });
+    } finally {
+      if (!createdUserEmails.length) {
+        return;
+      }
+
+      await userSettingPage.navigateToUsersSettingPage();
+
+      for (const email of [...createdUserEmails].reverse()) {
+        await userSettingPage.deleteUserByEmail(email).catch((error: unknown) => {
+          console.warn(`Cleanup failed for user ${email}:`, error);
+        });
+      }
     }
-  }
+  });
 });

--- a/tests/e2e/specs/board.spec.ts
+++ b/tests/e2e/specs/board.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '../../fixtures/auth.fixture';
+import { BoardPage } from '../pageObjects/BoardPage';
+
+const PROJECT_NAME = `Test Project ${Date.now()}`;
+const BOARD_NAME = `Test Board ${Date.now()}`;
+
+test.describe('Board management', () => {
+  test('admin can create a board', { tag: '@smoke' }, async ({ authenticatedPage: page }) => {
+    const boardPage = new BoardPage(page);
+    let projectId = '';
+
+    try {
+      await test.step('Create a project', async () => {
+        projectId = await boardPage.createProject(PROJECT_NAME);
+        expect(projectId).not.toBe('');
+      });
+
+      await test.step('Create a board inside the project', async () => {
+        const boardId = await boardPage.createBoard(BOARD_NAME, PROJECT_NAME);
+        expect(boardId).not.toBe('');
+      });
+
+      await test.step('Verify the board page is displayed', async () => {
+        await expect(page).toHaveURL(/\/boards\/\w+/);
+        await expect(page.locator(`div[title='${BOARD_NAME}']`)).toBeVisible({ timeout: 10000 });
+      });
+    } finally {
+      await boardPage.deleteBoard().catch((e) => console.warn('Board cleanup failed:', e));
+      if (projectId) {
+        await boardPage.deleteProject(projectId).catch((e) => console.warn('Project cleanup failed:', e));
+      }
+    }
+  });
+
+  test('admin can add a list to a board', { tag: '@smoke' }, async ({ authenticatedPage: page }) => {
+    const boardPage = new BoardPage(page);
+    const listName = `Todo ${Date.now()}`;
+    let projectId = '';
+
+    try {
+      await test.step('Create project and board', async () => {
+        projectId = await boardPage.createProject(`${PROJECT_NAME}-list`);
+        await boardPage.createBoard(`${BOARD_NAME}-list`, `${PROJECT_NAME}-list`);
+      });
+
+      await test.step('Add a list to the board', async () => {
+        await boardPage.createList(listName);
+      });
+
+      await test.step('Verify the list appears on the board', async () => {
+        await expect(page.locator(`div[title='${listName}']`)).toBeVisible();
+      });
+    } finally {
+      await boardPage.deleteBoard().catch((e) => console.warn('Board cleanup failed:', e));
+      if (projectId) {
+        await boardPage.deleteProject(projectId).catch((e) => console.warn('Project cleanup failed:', e));
+      }
+    }
+  });
+
+  test('cannot create a board without a name', async ({ authenticatedPage: page }) => {
+    const boardPage = new BoardPage(page);
+    let projectId = '';
+
+    try {
+      await test.step('Create a project', async () => {
+        projectId = await boardPage.createProject(`${PROJECT_NAME}-validation`);
+      });
+
+      await test.step('Open the add board popup and submit without a name', async () => {
+        await page.locator("button[title='Add Board']").first().click();
+        await page.locator("button[title='Add Board']").nth(1).click();
+      });
+
+      await test.step('Verify the form is still open and no navigation occurred', async () => {
+        await expect(page.locator("input[placeholder='Enter board name...']")).toBeVisible();
+        await expect(page).not.toHaveURL(/\/boards\/\w+/);
+      });
+    } finally {
+      if (projectId) {
+        await page.keyboard.press('Escape');
+        await boardPage.deleteProject(projectId).catch((e) => console.warn('Project cleanup failed:', e));
+      }
+    }
+  });
+
+  test('cannot create a list without a name', async ({ authenticatedPage: page }) => {
+    const boardPage = new BoardPage(page);
+    let projectId = '';
+
+    try {
+      await test.step('Create project and board', async () => {
+        projectId = await boardPage.createProject(`${PROJECT_NAME}-list-validation`);
+        await boardPage.createBoard(`${BOARD_NAME}-list-validation`, `${PROJECT_NAME}-list-validation`);
+      });
+
+      await test.step('Open add list form and press Enter with empty name', async () => {
+        await page.locator("button[title='Add List']").click();
+        const textarea = page.locator("textarea[placeholder='Enter list name...']");
+        await textarea.waitFor({ state: 'visible' });
+        await textarea.press('Enter');
+      });
+
+      await test.step('Verify the list form stays open with validation error', async () => {
+        await expect(page.locator("textarea[placeholder='Enter list name...']")).toBeVisible();
+      });
+    } finally {
+      await boardPage.deleteBoard().catch((e) => console.warn('Board cleanup failed:', e));
+      if (projectId) {
+        await boardPage.deleteProject(projectId).catch((e) => console.warn('Project cleanup failed:', e));
+      }
+    }
+  });
+});

--- a/tests/e2e/specs/card.spec.ts
+++ b/tests/e2e/specs/card.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '../../fixtures/auth.fixture';
+import { loginAsAdmin } from '../../fixtures/auth.fixture';
+import { LoginPage } from '../pageObjects/LoginPage';
+import { BoardPage } from '../pageObjects/BoardPage';
+import { CardPage } from '../pageObjects/CardPage';
+
+const PROJECT_NAME = `Card Test Project ${Date.now()}`;
+const BOARD_NAME = `Card Test Board ${Date.now()}`;
+const LIST_NAME = 'To Do';
+
+test.describe('Card management', () => {
+  let projectId: string;
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await loginAsAdmin(page);
+    const boardPage = new BoardPage(page);
+    projectId = await boardPage.createProject(PROJECT_NAME);
+    await boardPage.createBoard(BOARD_NAME, PROJECT_NAME);
+    await boardPage.createList(LIST_NAME);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await loginAsAdmin(page);
+    const boardPage = new BoardPage(page);
+    await page.locator(`[title='${BOARD_NAME}']`).first().click();
+    await boardPage.deleteBoard().catch((e) => console.warn('Board cleanup failed:', e));
+    if (projectId) {
+      await boardPage.deleteProject(projectId).catch((e) => console.warn('Project cleanup failed:', e));
+    }
+    await page.close();
+  });
+
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await page.locator(`[title='${BOARD_NAME}']`).first().click();
+    await expect(page).toHaveURL(/\/boards\/\w+/);
+  });
+
+  test('admin can create a card in a list', { tag: '@smoke' }, async ({ authenticatedPage: page }) => {
+    const cardPage = new CardPage(page);
+    const cardName = `My Card ${Date.now()}`;
+
+    await test.step('Create a card', async () => {
+      await cardPage.createCard(cardName);
+    });
+
+    await test.step('Verify the card appears in the list', async () => {
+      await expect(page.locator(`div[title='${cardName}']`)).toBeVisible();
+    });
+  });
+
+  test('admin can open and close a card modal', async ({ authenticatedPage: page }) => {
+    const cardPage = new CardPage(page);
+    const cardName = `Modal Card ${Date.now()}`;
+
+    await test.step('Create a card', async () => {
+      await cardPage.createCard(cardName);
+    });
+
+    await test.step('Open the card modal', async () => {
+      await cardPage.openCard(cardName);
+    });
+
+    await test.step('Verify the card modal is open', async () => {
+      await expect(page.locator("button[title='Close Card']")).toBeVisible();
+      await expect(page).toHaveURL(/\/cards\/\w+/);
+    });
+
+    await test.step('Close the card modal', async () => {
+      await cardPage.closeCard();
+      await expect(page).toHaveURL(/\/boards\/\w+/);
+    });
+  });
+});

--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -1,20 +1,39 @@
 import { test, expect } from '@playwright/test';
 import { LoginPage } from '../pageObjects/LoginPage';
 
-test('admin user logs in with valid credentials', async ({ page }) => {
-  const loginPage = new LoginPage(page);
+test.describe('Authentication', () => {
+  test('admin logs in with valid credentials', { tag: '@smoke' }, async ({ page }) => {
+    const loginPage = new LoginPage(page);
 
-  await test.step('Navigate to login page', async () => {
-    await loginPage.navigateToLoginPage();
-    await expect(page).toHaveURL(loginPage.loginUrl);
+    await test.step('Navigate to login page', async () => {
+      await loginPage.navigateToLoginPage();
+      await expect(page).toHaveURL(loginPage.loginUrl);
+    });
+
+    await test.step('Log in with admin credentials', async () => {
+      await loginPage.loginToDashboard('demo', 'demo');
+    });
+
+    await test.step('Validate dashboard is visible', async () => {
+      await expect(page).toHaveURL(loginPage.dashboardUrl);
+      await expect(loginPage.dashboardTitle).toBeVisible({ timeout: 15000 });
+    });
   });
 
-  await test.step('Log in with admin credentials', async () => {
-    await loginPage.loginToDashboard('demo', 'demo');
-  });
+  test('shows error message with invalid credentials', async ({ page }) => {
+    const loginPage = new LoginPage(page);
 
-  await test.step('Validate dashboard is visible', async () => {
-    await expect(page).toHaveURL(loginPage.dashboardUrl);
-    await expect(loginPage.dashboardTitle).toBeVisible({ timeout: 15000 });
+    await test.step('Navigate to login page', async () => {
+      await loginPage.navigateToLoginPage();
+    });
+
+    await test.step('Submit wrong password', async () => {
+      await loginPage.loginToDashboard('demo', 'wrong_password');
+    });
+
+    await test.step('Verify error is shown and user stays on login page', async () => {
+      await expect(page.locator("div[title='Invalid username or password']")).toBeVisible({ timeout: 10000 });
+      await expect(page).toHaveURL(loginPage.loginUrl);
+    });
   });
 });

--- a/tests/fixtures/auth.fixture.ts
+++ b/tests/fixtures/auth.fixture.ts
@@ -1,0 +1,20 @@
+import { test as base, expect, Page } from '@playwright/test';
+import { LoginPage } from '../e2e/pageObjects/LoginPage';
+
+const ADMIN = { username: 'demo', password: 'demo' };
+
+export async function loginAsAdmin(page: Page): Promise<void> {
+  const loginPage = new LoginPage(page);
+  await loginPage.navigateToLoginPage();
+  await loginPage.loginToDashboard(ADMIN.username, ADMIN.password);
+  await expect(page).toHaveURL(loginPage.dashboardUrl, { timeout: 15000 });
+}
+
+export const test = base.extend<{ authenticatedPage: Page }>({
+  authenticatedPage: async ({ page }, use) => {
+    await loginAsAdmin(page);
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   timeout: 30_000,
   reporter: [['list'], ['html', { open: 'never' }]],
   use: {


### PR DESCRIPTION
- Add board.spec.ts and card.spec.ts covering happy path and negative cases
- Add BoardPage and CardPage page objects
- Add auth fixture to share login logic across specs
- Refactor login and addUser specs to use fixture
- Add negative test for invalid login credentials
- Fix Delete user selector case in UserSettingPage
- Set workers=1 for serial execution
- Add test-plan.md and ai-interaction.md